### PR TITLE
Makes examples less repetitive, adds some explanation, removes unnecessary steps from some examples.

### DIFF
--- a/demo0.rb
+++ b/demo0.rb
@@ -8,9 +8,9 @@ class TestObject < ActiveFedora::Base
 end
 
 # create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: "Dr. Seuss" )
-obj.ds1.content = "Test Datastream Content"
-obj.ds1.original_name = 'test.txt'
+obj = TestObject.new( title: "Oh, the Places You'll Go!", creator: "Dr. Seuss" )
+obj.ds1.content = "Congratulations! Today is your day. You're off to Great Places! You're off and away!"
+obj.ds1.original_name = 'oh the places youll go.txt'
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"
 Launchy.open( "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}")

--- a/demo1.rb
+++ b/demo1.rb
@@ -6,7 +6,7 @@ class TestObject < ActiveFedora::Base
   property :creator, predicate: RDF::DC11.creator
 end
 
-# create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: "Dr. Seuss" )
+# create an object with some properties set
+obj = TestObject.new( title: "Green Eggs and Ham", creator: "Dr. Seuss" )
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"

--- a/demo2.rb
+++ b/demo2.rb
@@ -7,9 +7,10 @@ class TestObject < ActiveFedora::Base
   has_file_datastream name: 'ds1'
 end
 
-# create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: "Dr. Seuss" )
-obj.ds1.content = "Test Datastream Content"
-obj.ds1.original_name = 'test.txt'
+# Create an object and set a property and datastream content
+# When you download datastreams from fedora, the filename will be whatever you set as its original_name
+obj = TestObject.new( title: "The Lorax", creator: "Dr. Seuss" )
+obj.ds1.content = "I speak for the trees."
+obj.ds1.original_name = 'lorax.txt'
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"

--- a/demo3.rb
+++ b/demo3.rb
@@ -18,8 +18,6 @@ dr_seuss = TestConcept.new( label: "Dr. Seuss" )
 dr_seuss.save
 
 # create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: dr_seuss.rdf_subject )
-obj.ds1.content = "Test Datastream Content"
-obj.ds1.original_name = 'test.txt'
+obj = TestObject.new( title: "The Cat in the Hat", creator: dr_seuss.rdf_subject )
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"

--- a/demo4.rb
+++ b/demo4.rb
@@ -7,14 +7,15 @@ class TestObject < ActiveFedora::Base
   has_file_datastream name: 'ds1'
 end
 
-# create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: "Dr. Seuss" )
-obj.ds1.content = "Test Datastream Content"
+# create an object and a datastream, then update the datasream's content once,
+# causing the datastream to have two versions in its history
+obj = TestObject.new( title: "One Fish Two Fish", creator: "Dr. Seuss" )
+obj.ds1.content = "One Fish, Two Fish"
 obj.ds1.original_name = 'test.txt'
 obj.save
 
 obj.ds1.create_version
-obj.ds1.content = "New Version of Datastream Content"
+obj.ds1.content = "Red Fish, Blue Fish"
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"
 

--- a/demo5.rb
+++ b/demo5.rb
@@ -1,4 +1,6 @@
 # 5. xml datastreams still work
+# If you are creating new objects with Fedora, we discourage using XML datastreams.
+# They are prevalent in legacy systems, so must be supported, but it's best to use the default RDF behaviors.
 require 'active_fedora'
 
 class TestObject < ActiveFedora::Base
@@ -10,9 +12,9 @@ class TestObject < ActiveFedora::Base
 end
 
 # create an object and set a property and datastream content
-obj = TestObject.new( title: "Test Object Title", creator: "Dr. Seuss" )
-obj.publisher = "Random House"
-obj.ds1.content = "Test Datastream Content"
-obj.ds1.original_name = 'test.txt'
+obj = TestObject.new( title: "A Wrinkle in Time", creator: "Madeleine L’Engle" )
+obj.publisher = "Macmillan"
+obj.ds1.content = "Life, with its rules, its obligations, and its freedoms, is like a sonnet: You're given the form, but you have to write the sonnet yourself."
+obj.ds1.original_name = 'a wrinkle in time.txt'
 obj.save
 puts "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{obj.pid}"


### PR DESCRIPTION
This demo is useful for getting an orientation with using active-fedora 8.  I got stuck on a few things:
1. I couldn't keep track of which object I was looking at because the pids are so long and the titles were all the same
2. All of the demos create a datastream and add content to it, even when it's not part of the demo. This made it seem like you _had_ to always add a datastream
3. I wanted a slightly stronger hint of what each demo is doing

so I added these changes to remedy those issues (slightly).
